### PR TITLE
Add surge.sh deployments to preview PR changes

### DIFF
--- a/.surgeignore
+++ b/.surgeignore
@@ -1,0 +1,2 @@
+App_Data
+pyenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ cache:
     - _site/pyenv
 
 before_install:
+  - test $TRAVIS_PULL_REQUEST && ./.travis/pr_status pending "Waiting for website to build"
+
   # We need Ruby to build the Jekyll site, so setup Ruby 2.2.5 because a Python project has
   # Ruby 1.8.x installed by default
   - rvm install 2.2.5
@@ -25,8 +27,19 @@ script:
   - bash .travis/build.sh
 before_deploy:
   - bash .travis/pre-deploy.sh
+
+after_success:
+  - test $TRAVIS_PULL_REQUEST && ./.travis/pr_deploy
+after_failure:
+  - test $TRAVIS_PULL_REQUEST && ./.travis/pr_status error "Website failed to build"
+
 deploy:
   provider: azure_web_apps
 env:
   global:
+    - GITHUB_AUTH_USER=allejo
+    - GITHUB_USER=CityofSantaMonica
+    - GITHUB_REPO=analytics.smgov.net
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+notifications:
+  email: false

--- a/.travis/pr_deploy
+++ b/.travis/pr_deploy
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+URL="https://$GITHUB_USER--$GITHUB_REPO--$TRAVIS_PULL_REQUEST.surge.sh"
+if [ ! -f /usr/local/bin/surge ]; then npm install -g surge; fi
+surge --project ./_site --domain "$URL" > /dev/null
+SURGE_STATUS=$?
+STATUS=$([ $SURGE_STATUS -eq 0 ] && echo "success" || echo "failure")
+DESC=$([ $SURGE_STATUS -eq 0 ] && echo "Staging website deployed successfully" || echo "Staging website deployment failed")
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+bash $DIR/pr_status "$STATUS" "$DESC" "$URL"

--- a/.travis/pr_status
+++ b/.travis/pr_status
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+STATUS=$1
+DESC=$2
+URL=$3
+
+data="{\"state\":\"$STATUS\","
+if [ ! -z "$URL" ]
+then
+    data="$data\"target_url\":\"$URL\","
+fi
+data="$data\"description\":\"$DESC\",\"context\":\"surge.sh/staging\"}"
+
+curl -u $GITHUB_AUTH_USER:$GITHUB_PR_TOKEN --data "$data" "https://api.github.com/repos/$GITHUB_USER/$GITHUB_REPO/statuses/$TRAVIS_PULL_REQUEST_SHA" > /dev/null

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,6 @@
+include:
+- ".surgeignore"
+
 exclude:
 - ".jekyll-metadata"
 - ".gitignore"


### PR DESCRIPTION
As a security precaution, [Travis will only build PRs that reference branches from *this* repository and **not** any forks](https://docs.travis-ci.com/user/pull-requests#Pull-Requests-and-Security-Restrictions). For example, it'll build the `feature/surge-deploy-49` branch but it will not build it if the PR came from my fork.

The Jekyll website will be deployed to URLs that use the following pattern:

```
http://GITHUB_ORG--GITHUB_REPO--PR_NUMBER.surge.sh
```

Any custom functionality such as our web jobs will **not** be deployed to this staging preview. This is only meant to preview changes made to the Jekyll site.

## Possible Status Messages

- "Staging website deployed successfully" - appears when everything goes well and the site is successfully deployed to surge.sh
- "Staging website deployment failed" - appears when the deployment of the websites fails but the site **does** build
- "Website failed to build" - appears when the site failed to build and therefore the site could not be deployed to surge.

## Travis Env Variables

**Public**

This are set in `.travis.yml` as they're not sensitive

- `GITHUB_AUTH_USER` - The username of the account the OAuth token belongs to
- `GITHUB_USER` - The username or organization of this repository
- `GITHUB_REPO` - The name of this repository; no special characters that aren't URL friendly

**Private**

This are set through Travis' "Environment Variables" in order to keep them secured

- `GITHUB_PR_TOKEN` - A [GitHub OAuth token](https://help.github.com/articles/git-automation-with-oauth-tokens/) from a person with write access to the repository. The token only requires the `repo:status` permission.
- `SURGE_LOGIN` - The email used for the surge.sh account
- `SURGE_TOKEN` - The [API token](https://surge.sh/help/integrating-with-travis-ci) used to publish to surge.sh without a password

## Notes

Right now, to test/use this I've set an OAuth token from my GitHub account in Travis and same with the Surge credentials. For discussion:

- Do we want to create a [machine user](https://developer.github.com/guides/managing-deploy-keys/#machine-users) to use for generic purposes like this?
- Do we want a generic SM account for surge.sh deployments?
- The test currently appears as `surge.sh/staging` should it be renamed to something else?
- Is #20 something that can be done in the immediate feature or should I stick to deploying the previews to HTTP instead of HTTPS?
- See `.surgeignore` for files that we'll be ignoring when deploying a staging site since they aren't critical to the Jekyll site

Closes #49 