### PR TITLE
Implement HTTPS

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+   <rewrite>
+    <rules>
+     <rule name="ForceHTTPS">
+      <match url="(.*)"/>
+      <conditions>
+       <add input="{HTTPS}" pattern="Off"/>
+      </conditions>
+      <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" redirectType="Permanent" />
+     </rule>
+    </rules>
+   </rewrite>
+  </system.webServer>
+</configuration>

--- a/_config.yml
+++ b/_config.yml
@@ -18,13 +18,13 @@ slug: "The City of Santa Monica's web traffic."
 description: "Official data on web traffic to City of Santa Monica websites."
 
 # Site's own URL
-url: http://analytics.smgov.net
+url: https://analytics.smgov.net
 
 # Default dropdown title, will not appear if there are no sub-pages
 dropdown_title: All Participating Websites
 
 # Default data url
-data_url: http://analytics.smgov.net/data
+data_url: https://analytics.smgov.net/data
 
 # GitHub information
 org_name: CityofSantaMonica

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -459,7 +459,7 @@
           </div>
           <div class="column-half links">
             <ul class="list-inline">
-              <li><a href="http://www.smgov.net">City Website</a></li>
+              <li><a href="https://www.smgov.net">City Website</a></li>
               <li><a href="http://open.smgov.net">Open SMGov</a></li>
               <li><a href="https://data.smgov.net/">Open Data</a></li>
             </ul>


### PR DESCRIPTION
The cert has already been applied to Azure site, so this loads: https://analytics.smgov.net

This PR does 2 things:

  - Permanently redirects requests for the HTTP version, to the HTTPS version
  - Updates the config URLs so e.g. generated data URLs use HTTPS

Closes #20 