### PR TITLE
Change how the environment variables for websites are handled

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,18 @@ twitter: santamonicacity
 
 # Reporting
 collections:
-  - reports
+  reports:
+    output: false
+  websites:
+    output: true
+
+defaults:
+  - scope:
+      path: ''
+      type: websites
+    values:
+      layout: env
+      permalink: /envs/:name.env
 
 # site settings
 settings:

--- a/_layouts/env.html
+++ b/_layouts/env.html
@@ -1,0 +1,5 @@
+{% capture env %}
+export ANALYTICS_REPORT_IDS="ga:{{page.report}}"
+export ANALYTICS_HOSTNAME={{page.hostname}}
+{% if page.realtime %}export REALTIME=true{% endif %}
+{% endcapture %}{{ env | strip }}

--- a/_websites/analytics.md
+++ b/_websites/analytics.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica Analytics
 report: "120711164"
-hostname: analytics.smgov.net
+hostname: https://analytics.smgov.net
 realtime: true
 ---

--- a/_websites/analytics.md
+++ b/_websites/analytics.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica Analytics
+report: "120711164"
+hostname: analytics.smgov.net
+realtime: true
+---

--- a/_websites/annualreport.md
+++ b/_websites/annualreport.md
@@ -1,6 +1,6 @@
 ---
 name: Annual Report
 report: "120699529"
-hostname: annualreport.smgov.net
+hostname: https://annualreport.smgov.net
 realtime: false
 ---

--- a/_websites/annualreport.md
+++ b/_websites/annualreport.md
@@ -1,0 +1,6 @@
+---
+name: Annual Report
+report: "120699529"
+hostname: annualreport.smgov.net
+realtime: false
+---

--- a/_websites/bbb.md
+++ b/_websites/bbb.md
@@ -1,0 +1,6 @@
+---
+name: Big Blue Bus
+report: "120712925"
+hostname: www.bigbluebus.com
+realtime: true
+---

--- a/_websites/bbb.md
+++ b/_websites/bbb.md
@@ -1,6 +1,6 @@
 ---
 name: Big Blue Bus
 report: "120712925"
-hostname: www.bigbluebus.com
+hostname: https://www.bigbluebus.com
 realtime: true
 ---

--- a/_websites/beta.md
+++ b/_websites/beta.md
@@ -1,6 +1,6 @@
 ---
 name: Beta smgov.net
 report: "120998210"
-hostname: beta.smgov.net
+hostname: https://beta.smgov.net
 realtime: true
 ---

--- a/_websites/beta.md
+++ b/_websites/beta.md
@@ -1,0 +1,6 @@
+---
+name: Beta smgov.net
+report: "120998210"
+hostname: beta.smgov.net
+realtime: true
+---

--- a/_websites/citynet.md
+++ b/_websites/citynet.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica CityNet
 report: "123484109"
-hostname: www.smcitynet.com
+hostname: http://www.smcitynet.com
 realtime: false
 ---

--- a/_websites/citynet.md
+++ b/_websites/citynet.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica CityNet
+report: "123484109"
+hostname: www.smcitynet.com
+realtime: false
+---

--- a/_websites/downtownsmplan.md
+++ b/_websites/downtownsmplan.md
@@ -1,6 +1,6 @@
 ---
 name: Downtown Santa Monica Plan
 report: "120699339"
-hostname: www.downtownsmplan.org
+hostname: http://www.downtownsmplan.org
 realtime: false
 ---

--- a/_websites/downtownsmplan.md
+++ b/_websites/downtownsmplan.md
@@ -1,0 +1,6 @@
+---
+name: Downtown Santa Monica Plan
+report: "120699339"
+hostname: www.downtownsmplan.org
+realtime: false
+---

--- a/_websites/finance.md
+++ b/_websites/finance.md
@@ -1,0 +1,6 @@
+---
+name: Finance Website
+report: "122302513"
+hostname: finance.smgov.net
+realtime: true
+---

--- a/_websites/finance.md
+++ b/_websites/finance.md
@@ -1,6 +1,6 @@
 ---
 name: Finance Website
 report: "122302513"
-hostname: finance.smgov.net
+hostname: https://finance.smgov.net
 realtime: true
 ---

--- a/_websites/gtfs.md
+++ b/_websites/gtfs.md
@@ -1,0 +1,6 @@
+---
+name: Big Blue Bus GTFS
+report: "120708421"
+hostname: gtfs.bigbluebus.com
+realtime: false
+---

--- a/_websites/gtfs.md
+++ b/_websites/gtfs.md
@@ -1,6 +1,6 @@
 ---
 name: Big Blue Bus GTFS
 report: "120708421"
-hostname: gtfs.bigbluebus.com
+hostname: http://gtfs.bigbluebus.com
 realtime: false
 ---

--- a/_websites/newsroom.md
+++ b/_websites/newsroom.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica News Room
+report: "120724424"
+hostname: newsroom.smgov.net
+realtime: true
+---

--- a/_websites/newsroom.md
+++ b/_websites/newsroom.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica News Room
 report: "120724424"
-hostname: newsroom.smgov.net
+hostname: https://newsroom.smgov.net
 realtime: true
 ---

--- a/_websites/open.md
+++ b/_websites/open.md
@@ -1,6 +1,6 @@
 ---
 name: Open Data
 report: "120713631"
-hostname: open.smgov.net
+hostname: http://open.smgov.net
 realtime: false
 ---

--- a/_websites/open.md
+++ b/_websites/open.md
@@ -1,0 +1,6 @@
+---
+name: Open Data
+report: "120713631"
+hostname: open.smgov.net
+realtime: false
+---

--- a/_websites/santamonicacradletocareer.md
+++ b/_websites/santamonicacradletocareer.md
@@ -1,6 +1,6 @@
 ---
 name: Cradle to Career
 report: "120913395"
-hostname: santamonicacradletocareer.org
+hostname: https://santamonicacradletocareer.org
 realtime: false
 ---

--- a/_websites/santamonicacradletocareer.md
+++ b/_websites/santamonicacradletocareer.md
@@ -1,0 +1,6 @@
+---
+name: Cradle to Career
+report: "120913395"
+hostname: santamonicacradletocareer.org
+realtime: false
+---

--- a/_websites/santamonicafire.md
+++ b/_websites/santamonicafire.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica Fire
 report: "120712928"
-hostname: www.santamonicafire.org
+hostname: https://www.santamonicafire.org
 realtime: true
 ---

--- a/_websites/santamonicafire.md
+++ b/_websites/santamonicafire.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica Fire
+report: "120712928"
+hostname: www.santamonicafire.org
+realtime: true
+---

--- a/_websites/santamonicaparks.md
+++ b/_websites/santamonicaparks.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica Parks
 report: "120716231"
-hostname: www.santamonicaparks.org
+hostname: https://www.santamonicaparks.org
 realtime: false
 ---

--- a/_websites/santamonicaparks.md
+++ b/_websites/santamonicaparks.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica Parks
+report: "120716231"
+hostname: www.santamonicaparks.org
+realtime: false
+---

--- a/_websites/santamonicapd.md
+++ b/_websites/santamonicapd.md
@@ -1,6 +1,6 @@
 ---
 name: SMPD
 report: "120699580"
-hostname: www.santamonicapd.org
+hostname: https://www.santamonicapd.org
 realtime: true
 ---

--- a/_websites/santamonicapd.md
+++ b/_websites/santamonicapd.md
@@ -1,0 +1,6 @@
+---
+name: SMPD
+report: "120699580"
+hostname: www.santamonicapd.org
+realtime: true
+---

--- a/_websites/smgov.md
+++ b/_websites/smgov.md
@@ -1,0 +1,6 @@
+---
+name: Main Website
+report: "120498345"
+hostname: www.smgov.net
+realtime: true
+---

--- a/_websites/smgov.md
+++ b/_websites/smgov.md
@@ -1,6 +1,6 @@
 ---
 name: Main Website
 report: "120498345"
-hostname: www.smgov.net
+hostname: https://www.smgov.net
 realtime: true
 ---

--- a/_websites/smpl.md
+++ b/_websites/smpl.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica Public Library
+report: "120720923"
+hostname: smpl.org
+realtime: true
+---

--- a/_websites/smpl.md
+++ b/_websites/smpl.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica Public Library
 report: "120720923"
-hostname: smpl.org
+hostname: https://smpl.org
 realtime: true
 ---

--- a/_websites/smvote.md
+++ b/_websites/smvote.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica Vote
+report: "120703926"
+hostname: www.smvote.org
+realtime: true
+---

--- a/_websites/smvote.md
+++ b/_websites/smvote.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica Vote
 report: "120703926"
-hostname: www.smvote.org
+hostname: http://www.smvote.org
 realtime: true
 ---

--- a/_websites/tongvapark.md
+++ b/_websites/tongvapark.md
@@ -1,0 +1,6 @@
+---
+name: Tongva Park Website
+report: "120927208"
+hostname: tongvapark.smgov.net
+realtime: false
+---

--- a/_websites/tongvapark.md
+++ b/_websites/tongvapark.md
@@ -1,6 +1,6 @@
 ---
 name: Tongva Park Website
 report: "120927208"
-hostname: tongvapark.smgov.net
+hostname: https://tongvapark.smgov.net
 realtime: false
 ---

--- a/_websites/water.md
+++ b/_websites/water.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica Water
+report: "120711619"
+hostname: water.smgov.net
+realtime: false
+---

--- a/_websites/water.md
+++ b/_websites/water.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica Water
 report: "120711619"
-hostname: water.smgov.net
+hostname: http://water.smgov.net
 realtime: false
 ---

--- a/_websites/wellbeing.md
+++ b/_websites/wellbeing.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica Wellbeing Project
+report: "120700526"
+hostname: wellbeing.smgov.net
+realtime: false
+---

--- a/_websites/wellbeing.md
+++ b/_websites/wellbeing.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica Wellbeing Project
 report: "120700526"
-hostname: wellbeing.smgov.net
+hostname: http://wellbeing.smgov.net
 realtime: false
 ---

--- a/_websites/youthtech.md
+++ b/_websites/youthtech.md
@@ -1,6 +1,6 @@
 ---
 name: Santa Monica Youth Tech Program
 report: "123479717"
-hostname: www.santamonicayouthtech.com
+hostname: http://www.santamonicayouthtech.com
 realtime: false
 ---

--- a/_websites/youthtech.md
+++ b/_websites/youthtech.md
@@ -1,0 +1,6 @@
+---
+name: Santa Monica Youth Tech Program
+report: "123479717"
+hostname: www.santamonicayouthtech.com
+realtime: false
+---

--- a/envs/analytics.env
+++ b/envs/analytics.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120711164"
-export ANALYTICS_HOSTNAME=analytics.smgov.net
-export REALTIME=true

--- a/envs/annualreport.env
+++ b/envs/annualreport.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120699529"
-export ANALYTICS_HOSTNAME=annualreport.smgov.net

--- a/envs/bbb.env
+++ b/envs/bbb.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120712925"
-export ANALYTICS_HOSTNAME=www.bigbluebus.com
-export REALTIME=true

--- a/envs/bbbstore.env
+++ b/envs/bbbstore.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:123168659"
-export ANALYTICS_HOSTNAME=store.bigbluebus.com

--- a/envs/beta.env
+++ b/envs/beta.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120998210"
-export ANALYTICS_HOSTNAME=beta.smgov.net
-export REALTIME=true

--- a/envs/citynet.env
+++ b/envs/citynet.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:123484109"
-export ANALYTICS_HOSTNAME=www.smcitynet.com

--- a/envs/downtownsmplan.env
+++ b/envs/downtownsmplan.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120699339"
-export ANALYTICS_HOSTNAME=www.downtownsmplan.org

--- a/envs/finance.env
+++ b/envs/finance.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:122302513"
-export ANALYTICS_HOSTNAME=finance.smgov.net
-export REALTIME=true

--- a/envs/gtfs.env
+++ b/envs/gtfs.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120708421"
-export ANALYTICS_HOSTNAME=gtfs.bigbluebus.com

--- a/envs/newsroom.env
+++ b/envs/newsroom.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120724424"
-export ANALYTICS_HOSTNAME=newsroom.smgov.net
-export REALTIME=true

--- a/envs/open.env
+++ b/envs/open.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120713631"
-export ANALYTICS_HOSTNAME=open.smgov.net

--- a/envs/santamonicacradletocareer.env
+++ b/envs/santamonicacradletocareer.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120913395"
-export ANALYTICS_HOSTNAME=santamonicacradletocareer.org

--- a/envs/santamonicafire.env
+++ b/envs/santamonicafire.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120712928"
-export ANALYTICS_HOSTNAME=www.santamonicafire.org
-export REALTIME=true

--- a/envs/santamonicaparks.env
+++ b/envs/santamonicaparks.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120716231"
-export ANALYTICS_HOSTNAME=www.santamonicaparks.org

--- a/envs/santamonicapd.env
+++ b/envs/santamonicapd.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120699580"
-export ANALYTICS_HOSTNAME=www.santamonicapd.org
-export REALTIME=true

--- a/envs/smgov.env
+++ b/envs/smgov.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120498345"
-export ANALYTICS_HOSTNAME=www.smgov.net
-export REALTIME=true

--- a/envs/smpl.env
+++ b/envs/smpl.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120720923"
-export ANALYTICS_HOSTNAME=smpl.org
-export REALTIME=true

--- a/envs/smvote.env
+++ b/envs/smvote.env
@@ -1,3 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120703926"
-export ANALYTICS_HOSTNAME=www.smvote.org
-export REALTIME=true

--- a/envs/tongvapark.env
+++ b/envs/tongvapark.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120927208"
-export ANALYTICS_HOSTNAME=tongvapark.smgov.net

--- a/envs/water.env
+++ b/envs/water.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120711619"
-export ANALYTICS_HOSTNAME=water.smgov.net

--- a/envs/wellbeing.env
+++ b/envs/wellbeing.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:120700526"
-export ANALYTICS_HOSTNAME=wellbeing.smgov.net

--- a/envs/youthtech.env
+++ b/envs/youthtech.env
@@ -1,2 +1,0 @@
-export ANALYTICS_REPORT_IDS="ga:123479717"
-export ANALYTICS_HOSTNAME=www.santamonicayouthtech.com

--- a/js/index.js
+++ b/js/index.js
@@ -268,7 +268,7 @@
           .append("a")
             .attr("target", "_blank")
             .attr("href", function(d) {
-              return exceptions[d.domain] || ("http://" + d.domain);
+              return exceptions[d.domain] || (d.domain);
             })
             .text(function(d) {
               return title_exceptions[d.domain] || d.domain;
@@ -303,7 +303,7 @@
               return d.page_title;
             })
             .attr("href", function(d) {
-              return exceptions[d.page] || ("http://" + d.domain + d.page);
+              return exceptions[d.page] || (d.domain + d.page);
             })
             .text(function(d) {
               return title_exceptions[d.page] || d.page_title;


### PR DESCRIPTION
Instead of `.env` files, handle them as collection items in Jekyll so we have access to all that information in our Liquid. A Jekyll layout exists to export the values into the expected `.env` format for Azure